### PR TITLE
Fix link to How Can I page

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -294,7 +294,7 @@ df = q.collect()
             <p>
               See more examples in the
               <a
-                href="https://pola-rs.github.io/polars-book/user-guide/howcani/"
+                href="https://pola-rs.github.io/polars-book/user-guide/howcani/intro.html"
                 >User Guide</a
               >.
             </p>


### PR DESCRIPTION
The current link gives a 404. I replaced the link with what I felt was the intended target page.