### PR TITLE
Homepage speedup/optimisation

### DIFF
--- a/build/templates/home.tpl
+++ b/build/templates/home.tpl
@@ -234,7 +234,7 @@ df = q.collect()</code></pre>
             c.login +
             '"><img src="' +
             c.avatar_url +
-            '" /></a>';
+            '&s=80" /></a>';
         });
       });
   </script>

--- a/build/templates/home.tpl
+++ b/build/templates/home.tpl
@@ -201,6 +201,7 @@ df = q.collect()</code></pre>
       <div class="pl-contribs">
         <h3><i class="fas fa-user-astronaut"></i>Contributors</h3>
         <div id="contributors"></div>
+        <a href="https://github.com/pola-rs/polars/graphs/contributors">and more...</>
       </div>
      
       <div class="pl-sponsors">
@@ -223,7 +224,7 @@ df = q.collect()</code></pre>
 
     axios
       .get(
-        "https://api.github.com/repos/pola-rs/polars/contributors?per_page=1000"
+        "https://api.github.com/repos/pola-rs/polars/contributors?per_page=40"
       )
       .then((resp) => {
         resp.data.forEach((c) => {


### PR DESCRIPTION
Observation
----
The `Contributors` section of the [homepage](https://www.pola.rs/) loads a whopping `5MB` of user avatars from GitHub at their original/max resolution and triggers a corresponding flurry of network requests and CPU activity. 

Optimisation
----
I've capped the number of contributors displayed at 40, which still looks good, adding an _"[and more...](https://github.com/pola-rs/polars/graphs/contributors)"_ link through to the contributors page so everyone still gets their due :)

<img width="1370" alt="contributors" src="https://user-images.githubusercontent.com/2613171/198893382-f9e4e62e-5ada-4cd0-a9b5-b429f4376b02.png"> 

More significantly I tweaked avatar retrieval so that an additional param is passed when loading the images, pulling in the correct size (80px) to begin with; this reduces data transfer by 10x...

Timings
----
_Caveat: these results will obviously depend _heavily_ on caching, network speed, etc..._

**Before:**

<img width="1552" alt="load_profile_before" src="https://user-images.githubusercontent.com/2613171/198896318-b04cb118-36ad-4f8e-95f9-15845780fc9c.png">

**After:**

<img width="1508" alt="load_profile_after" src="https://user-images.githubusercontent.com/2613171/198893663-941e16e2-b9e3-4487-95d1-a8de48b4bfeb.png">

Homepage loads several times faster now (could be faster still if the large/unused JS scripts weren't loaded until the subpages that require them are viewed, but that would need better separation when extending `base.tpl`, so that may be one for another day  ;)