### PR TITLE
Improve homepage/splash layout for monitors in portrait orientation

### DIFF
--- a/www/style.css
+++ b/www/style.css
@@ -220,6 +220,7 @@ header .pl-splash {
   flex-direction: column;
   height: 80vh;
   justify-content: center;
+  max-height: 650px;
   min-height: 400px;
   text-align: center;
 }


### PR DESCRIPTION
**Before / After:**

<img width="388" alt="homepage_layout_before" src="https://user-images.githubusercontent.com/2613171/198895678-3a0e8bca-b2c8-4dfa-b207-a6b77e034f54.png"> <img width="388" alt="homepage_layout_after" src="https://user-images.githubusercontent.com/2613171/198896058-f6c63742-c736-4d8c-9a4c-a14a82afa9f2.png">

