### PR TITLE
Allow navigating to API docs on touch screen devices

### DIFF
--- a/build/templates/base.tpl
+++ b/build/templates/base.tpl
@@ -88,7 +88,7 @@
           <div class="pl-buttons">
             <ul>
 
-              <li class="text">
+              <li class="text" onclick="this.classList.toggle('selected');">
                 <a>API</a>
                 <ul>
                   <li class="text">

--- a/www/style.css
+++ b/www/style.css
@@ -190,7 +190,8 @@ nav .menu .pl-buttons > ul li > ul {
   position: absolute;
 }
 
-nav .menu .pl-buttons > ul li:hover > ul {
+nav .menu .pl-buttons > ul li:hover > ul,
+nav .menu .pl-buttons > ul li.selected > ul {
   display: block;
 }
 


### PR DESCRIPTION
It's currently impossible to use for example iPad to browse the API docs as there's no :hover triggered on safari. With this PR you can toggle language menu visibility with a tap (click).