### PR TITLE
add sponsor `Ponte Energy Partners`

### DIFF
--- a/build/templates/home.tpl
+++ b/build/templates/home.tpl
@@ -213,6 +213,12 @@ df = q.collect()</code></pre>
             src="https://raw.githubusercontent.com/pola-rs/polars-static/master/sponsors/xomnia.png"
             title="Xomnia"
           /></a>
+          <a
+            href="https://ponte.energy"
+          ><img
+            src="https://raw.githubusercontent.com/pola-rs/polars-static/master/sponsors/ponte_energy_partners.png"
+            title="Ponte Energy Partners"
+          /></a>
         </p>
       </div>
  


### PR DESCRIPTION
[Ponte Energy Partners](https://github.com/Ponte-Energy-Partners) recently became **Silver company sponsor** of @ritchie46.

We would be thrilled to have our company logo shown on https://www.pola.rs.

I just created https://github.com/pola-rs/polars-static/pull/22 to provide the logo.

Please get in touch in case there are any questions or concerns. Thank you!