### PR TITLE
Fix sponsors CSS

### DIFF
--- a/www/style.css
+++ b/www/style.css
@@ -337,6 +337,12 @@ main section .pl-sponsors {
   text-align: center;
 }
 
+main section .pl-sponsors img {
+  display: block;
+  max-width: 200px;
+  margin: 10px auto;
+}
+
 footer {
   background-color: var(--background-color-alt);
   bottom: 0;


### PR DESCRIPTION
![polars_web](https://github.com/pola-rs/polars-web/assets/10058240/b207ccc2-5e9b-4e7e-bf2a-678c5287db69)

The style of the sponsors images don't look great, in particular after adding the new sponsor image, which is much bigger than the previous.

Changing the styles, so the different logos have a more consistent size, one per row, and with a decent margin (see screenshot).