### PR TITLE
remove all render-blocking js

### DIFF
--- a/build/templates/base.tpl
+++ b/build/templates/base.tpl
@@ -40,7 +40,6 @@
       document.documentElement.className = {{ theme }};
     </script>
     {% endif %}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.21.4/axios.min.js"></script>
     <script
       defer
       src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.3.1/highlight.min.js"
@@ -63,9 +62,9 @@
       );"
     ></script>
     <script
-      defer
-      src="https://cdnjs.cloudflare.com/ajax/libs/mermaid/8.13.3/mermaid.min.js"
-      onload="mermaid.initialize();"
+            defer
+            src="https://cdnjs.cloudflare.com/ajax/libs/mermaid/8.13.3/mermaid.min.js"
+            onload="mermaid.initialize();"
     ></script>
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="stylesheet" href="/style.css" />
@@ -166,6 +165,6 @@
 
       </div>
     </footer>
-
+  {% block footer_scripts %}{% endblock %}
   </body>
 </html>

--- a/build/templates/benchmarks.tpl
+++ b/build/templates/benchmarks.tpl
@@ -1,8 +1,7 @@
 {% extends "base.tpl" %}
 
 {% block head %}
-    <link rel="stylesheet" href="style.css"/>
-    <link rel="stylesheet" href="style-benchmark.css"/>
+    <link rel="stylesheet" href="/style-benchmark.css"/>
 {% endblock %}
 
 {% block main %}

--- a/build/templates/home.tpl
+++ b/build/templates/home.tpl
@@ -24,20 +24,6 @@
     </div>
 
   </div>
-
-  <script>
-    let s = document.getElementById("stargazers"),
-        f = document.getElementById("forks");
-
-    axios
-      .get("https://api.github.com/repos/pola-rs/polars")
-      .then((resp) => {
-        s.innerHTML =
-          (resp.data.stargazers_count / 1000).toFixed(1) + "k";
-        f.innerHTML = resp.data.forks_count;
-      });
-  </script>
-
 </header>
 {% endblock %}
 
@@ -86,7 +72,7 @@
         <div>
           <div>
             <img
-              height="80px"
+              height="80"
               src="https://raw.githubusercontent.com/pola-rs/polars-static/master/web/polars-logo-rust.svg"
             />
           </div>
@@ -201,7 +187,7 @@ df = q.collect()</code></pre>
       <div class="pl-contribs">
         <h3><i class="fas fa-user-astronaut"></i>Contributors</h3>
         <div id="contributors"></div>
-        <a href="https://github.com/pola-rs/polars/graphs/contributors">and more...</>
+        <a href="https://github.com/pola-rs/polars/graphs/contributors">and more...</a>
       </div>
 
       <div class="pl-sponsors">
@@ -212,18 +198,21 @@ df = q.collect()</code></pre>
           ><img
             src="https://raw.githubusercontent.com/pola-rs/polars-static/master/sponsors/xomnia.png"
             title="Xomnia"
+            alt="Xomnia logo"
           /></a>
           <a
             href="https://ponte.energy"
           ><img
             src="https://raw.githubusercontent.com/pola-rs/polars-static/master/sponsors/ponte_energy_partners.png"
             title="Ponte Energy Partners"
+            alt="Ponte Energy Partners logo"
           /></a>
           <a
             href="https://databento.com/"
           ><img
             src="https://raw.githubusercontent.com/pola-rs/polars-static/master/sponsors/databento-sponsorship-logo.png"
             title="databento"
+            alt="databento logo"
           /></a>
         </p>
       </div>
@@ -231,26 +220,30 @@ df = q.collect()</code></pre>
     </div>
   </div>
 
-  <script>
-    let e = document.getElementById("contributors");
 
-    axios
-      .get(
-        "https://api.github.com/repos/pola-rs/polars/contributors?per_page=40"
-      )
-      .then((resp) => {
-        resp.data.forEach((c) => {
-          e.innerHTML +=
-            '<a href="' +
-            c.html_url +
-            '" title="' +
-            c.login +
-            '"><img src="' +
-            c.avatar_url +
-            '&s=80" /></a>';
-        });
-      });
-  </script>
 
 </section>
+{% endblock %}
+
+{% block footer_scripts %}
+<script>
+  let s = document.getElementById("stargazers"),
+    f = document.getElementById("forks");
+
+    fetch("https://api.github.com/repos/pola-rs/polars")
+            .then(r => r.json())
+            .then((data) => {
+          s.innerHTML = (data.stargazers_count / 1000).toFixed(1) + "k";
+          f.innerHTML = data.forks_count;
+  });
+
+  let e = document.getElementById("contributors");
+  fetch("https://api.github.com/repos/pola-rs/polars/contributors?per_page=40")
+    .then(r => r.json())
+    .then(data => {
+      e.innerHTML = data.map((c) => {
+         return '<a href="' + c.html_url + '" title="'+ c.login +'"><img src="'+ c.avatar_url +'" alt="' + c.login + '" /></a>';
+      }).join('');
+    });
+</script>
 {% endblock %}

--- a/build/templates/post.tpl
+++ b/build/templates/post.tpl
@@ -2,7 +2,6 @@
 
 {% block head %}
 <link rel="stylesheet" href="/style-post.css" />
-<link rel="stylesheet" href="style.css" />
 {% endblock %}
 
 {% block main %}


### PR DESCRIPTION
This PR addresses a few random issues that should improve the site its Web Core Vitals' score: https://pagespeed.web.dev/analysis/https-www-pola-rs/f3nqbo9elp?form_factor=mobile 

- Remove unneeded axios dependency. The JS was already using ES6 arrow functions in other places, so we can be sure that [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) is natively available (site is already broken otherwise). 
- Move creation of contributors & GitHub stars HTML to footer so it doesn't block rendering.
- Update DOM in a single pass vs. consecutively appending to `innerHTML` (which is notoriously slow).
- Fix loading a 404 page as stylesheet on all posts pages, effectively loading the website twice.
- Fix some minor accessibility issues related to `<img>` elements without an `alt` attribute for screen reader software.

Also, `mermaid.js` is currently throwing an error on the live website but I wasn't sure where it was used exactly so I did not touch it. It may be worth looking at and maybe moving it (+ `kajax.js`) to the post template if it's only ever used in posts.