### PR TITLE
fix avatar img size regression

### DIFF
--- a/build/templates/base.tpl
+++ b/build/templates/base.tpl
@@ -68,6 +68,7 @@
     ></script>
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="stylesheet" href="/style.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" />
     {% block head %}{% endblock %}
   </head>
 

--- a/build/templates/home.tpl
+++ b/build/templates/home.tpl
@@ -242,7 +242,7 @@ df = q.collect()</code></pre>
     .then(r => r.json())
     .then(data => {
       e.innerHTML = data.map((c) => {
-         return '<a href="' + c.html_url + '" title="'+ c.login +'"><img src="'+ c.avatar_url +'" alt="' + c.login + '" /></a>';
+         return '<a href="' + c.html_url + '" title="'+ c.login +'"><img src="'+ c.avatar_url +'&s=80" alt="' + c.login + '" /></a>';
       }).join('');
     });
 </script>

--- a/www/style.css
+++ b/www/style.css
@@ -1,8 +1,3 @@
-@import url("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/fontawesome.min.css");
-@import url("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/brands.min.css");
-@import url("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/regular.min.css");
-@import url("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/solid.min.css");
-
 @import "style-github-button.css";
 @import "style-highlight.css";
 @import "style-themes.css";


### PR DESCRIPTION
While #78 did improve the Web Core Vitals score by nearly 10 points, the effect was less drastic as I hoped because I accidentally introduced a regression related to the avatar `<img>` sizes. :fearful:  

This PR fixes that and combined the 4 `@import` calls with a single `<link>` element which can be downloaded in a smarter way by browsers nowadays.